### PR TITLE
Fixes build issue with Xcode 26.4.

### DIFF
--- a/Sources/SurveySparrowSdk/SurveySparrow.swift
+++ b/Sources/SurveySparrowSdk/SurveySparrow.swift
@@ -65,7 +65,7 @@ public class SurveySparrow: SsSurveyDelegate {
         if promptTime == 0 {
             let nextPrompt = currentTime + startAfter
             UserDefaults.standard.set(nextPrompt, forKey: promptTimeKey)
-            dataStore.set(1, forKey: incrementMultiplierKey)
+            dataStore.set(1 as Int, forKey: incrementMultiplierKey)
             return
         }
         if self.domain != nil && self.token != nil {


### PR DESCRIPTION
**Problem**:
Compilation fails on Xcode 26.4 due to an ambiguous call to `set(_:forKey:)` in SurveySparrow.swift:68:
```swift
    dataStore.set(1, forKey: incrementMultiplierKey)
```
**Error**:
> Ambiguous use of 'set(_:forKey:)'

**Solution**:
Explicitly specify the type of the literal to resolve the ambiguity.

**Tested on**:
- Xcode 26.4